### PR TITLE
Feature/fckit fork

### DIFF
--- a/CMake/jedi_install_NetCDF_C.cmake
+++ b/CMake/jedi_install_NetCDF_C.cmake
@@ -11,7 +11,7 @@ function ( download_build_install )
            URL_MD5 ${netcdf_c_MD5}
 	   #CMAKE_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DENABLE_HDF4=OFF -DENABLE_DAP=ON -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
            CONFIGURE_COMMAND
-           <SOURCE_DIR>/configure --enable-pnetcdf --prefix=${JEDI_PREFIX}
+           <SOURCE_DIR>/configure --enable-pnetcdf --enable-parallel --enable-netcdf-4 --prefix=${JEDI_PREFIX}
            CC=${CMAKE_C_COMPILER}
            CFLAGS=${CFLAGS}
            FC=${CMAKE_Fortran_COMPILER}

--- a/CMake/jedi_install_NetCDF_C.cmake
+++ b/CMake/jedi_install_NetCDF_C.cmake
@@ -11,7 +11,7 @@ function ( download_build_install )
            URL_MD5 ${netcdf_c_MD5}
 	   #CMAKE_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DENABLE_HDF4=OFF -DENABLE_DAP=ON -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
            CONFIGURE_COMMAND
-           <SOURCE_DIR>/configure --enable-pnetcdf --enable-parallel --enable-netcdf-4 --prefix=${JEDI_PREFIX}
+           <SOURCE_DIR>/configure --enable-pnetcdf --prefix=${JEDI_PREFIX}
            CC=${CMAKE_C_COMPILER}
            CFLAGS=${CFLAGS}
            FC=${CMAKE_Fortran_COMPILER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,9 @@ RUN cd /usr/local/src \
     && make install \
     && cd ../../ \
     && rm -fr eckit \
-    && git clone https://github.com/ecmwf/fckit.git \
+    && git clone https://github.com/JCSDA/fckit.git \
     && cd fckit \
-    && git checkout 0.5.2 \
+    && git checkout develop \
     && mkdir build \
     && cd  build \
     && ecbuild --build=debug .. \


### PR DESCRIPTION
This installs the jcsda fork of fckit into the container, with enhanced mpi functionality.  This is necessary to run the new feature/fckit-mpi branch of oops, which will soon be merged into develop