### PR TITLE
feature/ncepbufr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,17 @@ RUN apt-get update \
     && make -j4 \
     && make install \
     && cd /usr/local/src \
-    && rm -fr *
+    && rm -fr * \
+# Compiile ncepbufr for python
+    && cd /usr/local/src \
+    && git clone https://github.com/JCSDA/py-ncepbufr.git \
+    && cd py-ncepbufr \
+    && CC=gcc python setup.py build \
+    && python setup.py install \
+    && CC=gcc python3 setup.py build \
+    && python3 setup.py install \
+    && cp src/libbufr.a /usr/local/lib \
+    && cd /usr/local/src \
+    && rm -rf *
 
 CMD ["/bin/bash" , "-l"]


### PR DESCRIPTION
This pull request installs python packages needed for ncepbufr and YAML parsing. This needs to be merged with the same named pull request in the docker_base repo. 

The only testing I've done is to verify that I can open and read a subset out of a BUFR file from Python. I'm happy to help with more testing once a Singularity and/or Charliecloud image is built.