### PR TITLE
Bugfix/python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout develop
+    && git checkout develop \
     && ./build_stack.sh "container" \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  jcsda/docker_base:beta
+FROM  jcsda/docker_base:latest
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
 # set environment variables manually
@@ -22,7 +22,7 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout feature/python \
+    && git checkout develop
     && ./build_stack.sh "container" \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  jcsda/docker_base:latest
+FROM  jcsda/docker_base:beta
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
 # set environment variables manually
@@ -11,7 +11,6 @@ ENV NETCDF=/usr/local \
    LAPACK_PATH=/usr/local \
    LAPACK_DIR=$LAPACK_PATH \
    LAPACK_LIBRARIES="$LAPACK_PATH/lib/liblapack.a;$LAPACK_PATH/lib/libblas.a" \
-   PYTHONPATH=/usr/local/lib/python2.7/site-packages \
    SERIAL_CC=gcc \
    SERIAL_CXX=g++ \
    SERIAL_FC=gfortran \
@@ -23,7 +22,7 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout develop \
+    && git checkout feature/python \
     && ./build_stack.sh "container" \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This just removes the hardwiring in of the PYTHONPATH.  I do not think it is required; when packages are installed via ```python3 -m pip install -U <pkg>```, python knows where to find them.  And, this works toward our eventual phase-out of python2.7.
If you want to confirm for yourself that this does not break anything you can try this Charliecloud container, which was build with this change:
~~~~~
wget https://data.jcsda.org/containers/ch-jedi-beta.tar.gz
~~~~~