### PR TITLE
added lcov

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,12 @@ ENV FC=mpifort \
    CC=mpicc \
    CXX=mpicxx
 
+# build lcov for Travis-CI
+RUN cd /usr/local/src \
+    && curl -L -O http://downloads.sourceforge.net/ltp/lcov-1.14.tar.gz \
+    && tar -xvf lcov-1.14.tar.gz \
+    && cd lcov-1.14 \
+    && make install \
+    && rm -rf /usr/local/src/*
+
 CMD ["/bin/bash" , "-l"]


### PR DESCRIPTION

This adds lcov to the Docker container to facilitate Travis-CI testing.  Currently this Dockerfile is only used to make the gnu container; the Dockerfile for the intel container is in the charliecloud repo.

@mer-a-o - the current jcsda/docker:latest image should have these changes implemented so please give it a try.