### PR TITLE
Feature/clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 sbin
 doc
 libexec
+build.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout develop \
-    && ./build_stack.sh "container" \
+    && git checkout feature/intel19-container \
+    && ./build_stack.sh "container-gnu-openmpi-dev" \
+    && mv ../jedi-stack-contents.log /etc && \
+    && chmod a+r /etc/jedi-stack-contents.log && \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout develop \
+    && git checkout feature/intel19-container \
     && ./build_stack.sh "container-gnu-openmpi-dev" \
-    && mv ../jedi-stack-contents.log /etc && \
-    && chmod a+r /etc/jedi-stack-contents.log && \
+    && mv ../jedi-stack-contents.log /etc \
+    && chmod a+r /etc/jedi-stack-contents.log \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout feature/intel19-container \
+    && git checkout develop \
     && ./build_stack.sh "container-gnu-openmpi-dev" \
     && mv ../jedi-stack-contents.log /etc && \
     && chmod a+r /etc/jedi-stack-contents.log && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout feature/intel19-container \
+    && git checkout develop \
     && ./build_stack.sh "container-gnu-openmpi-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -26,7 +26,7 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout feature/clang-container \
+    && git checkout develop \
     && ./build_stack.sh "container-clang-mpich-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -1,0 +1,60 @@
+FROM  jcsda/docker_base-clang-mpich-dev:latest
+LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
+
+# set environment variables manually
+ENV NETCDF=/usr/local \
+   PNETCDF=/usr/local \
+   HDF5_ROOT=/usr/local \
+   PIO=/usr/local \
+   BOOST_ROOT=/usr/local \
+   EIGEN3_INCLUDE_DIR=/usr/local \
+   LAPACK_PATH=/usr/local \
+   LAPACK_DIR=$LAPACK_PATH \
+   LAPACK_LIBRARIES="$LAPACK_PATH/lib/liblapack.a;$LAPACK_PATH/lib/libblas.a" \
+   SERIAL_CC=clang \
+   SERIAL_CXX=clang++ \
+   SERIAL_FC=gfortran \
+   MPI_CC=mpicc \
+   MPI_CXX=mpicxx \
+   MPI_FC=mpifort \
+   PATH=/usr/local/bin:$PATH \
+   LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
+   LIBRARY_PATH=/usr/local/lib:$LIBRARY_PATH \
+   CPATH=/usr/local/include:$CPATH
+
+# build the jedi stack
+RUN cd /root \
+    && git clone https://github.com/jcsda/jedi-stack.git \
+    && cd jedi-stack/buildscripts \
+    && git checkout feature/clang-container \
+    && ./build_stack.sh "container-clang-mpich-dev" \
+    && mv ../jedi-stack-contents.log /etc \
+    && chmod a+r /etc/jedi-stack-contents.log \
+    && rm -rf /root/jedi-stack \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /worktmp
+
+#Make a non-root user:jedi / group:jedi for running MPI
+RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi && \
+    echo "export FC=mpifort" >> ~jedi/.bashrc && \
+    echo "export CC=mpicc" >> ~jedi/.bashrc && \
+    echo "export CXX=mpicxx" >> ~jedi/.bashrc && \
+    echo "[credential]\n    helper = cache --timeout=7200" >> ~jedi/.gitconfig && \
+    mkdir ~jedi/.openmpi && \
+    echo "rmaps_base_oversubscribe = 1" >> ~jedi/.openmpi/mca-params.conf && \
+    chown -R jedi:jedi ~jedi/.gitconfig ~jedi/.openmpi
+
+#Setup the root users environment
+ENV FC=mpifort \
+   CC=mpicc \
+   CXX=mpicxx
+
+# build lcov for Travis-CI
+RUN cd /usr/local/src \
+    && curl -L -O http://downloads.sourceforge.net/ltp/lcov-1.14.tar.gz \
+    && tar -xvf lcov-1.14.tar.gz \
+    && cd lcov-1.14 \
+    && make install \
+    && rm -rf /usr/local/src/*
+
+CMD ["/bin/bash" , "-l"]

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -23,7 +23,9 @@ RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout develop \
-    && ./build_stack.sh "container" \
+    && ./build_stack.sh "container-gnu-openmpi-dev" \
+    && mv ../jedi-stack-contents.log /etc \
+    && chmod a+r /etc/jedi-stack-contents.log \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,8 @@ How to build the image
 
 .. code:: bash
 
- > docker image build -t jcsda/docker .
- > docker image push jcsda/docker
+ > docker image build -t jcsda/gnu-openmpi-dev .
+ > docker push jcsda/gnu-openmpi-dev
 
 
 *Please* `contact Mark Miesch`_, *if you need more libraries being included.*

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,9 @@ How to build the image
 
 .. code:: bash
 
- > docker image build -t jcsda/docker .
- > docker image push jcsda/docker
+  name="gnu-openmpi-dev"
+  docker image build --no-cache -f Dockerfile.$name -t jcsda/docker-$name . 2>&1 | tee build.log
+  docker push jcsda/docker-$name
 
 
 *Please* `contact Mark Miesch`_, *if you need more libraries being included.*

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,8 @@ How to build the image
 
 .. code:: bash
 
- > docker image build -t jcsda/gnu-openmpi-dev .
- > docker push jcsda/gnu-openmpi-dev
+ > docker image build -t jcsda/docker-gnu-openmpi-dev .
+ > docker push jcsda/docker-gnu-openmpi-dev
 
 
 *Please* `contact Mark Miesch`_, *if you need more libraries being included.*


### PR DESCRIPTION

This PR is accompanied by others in docker_base and jedi-stack.  Together they implement a new docker container that uses clang compilers for C and C++ and gfortran for fortran.  I used it to successfully build a docker_base container and a docker container, both of which are now on docker hub.  I also went into the docker container and tested ufo-bundle and all tests pass.  However, be sure to remember to run ```git lfs install``` before downloading the repos - that's enabled in the docker container for the root login but not the jedi login.

So, @mer-a-o  there is a ```jcsda/clang-mpich-dev``` container now on docker hub that is ready for CI testing when you are.
