### PR TITLE
Feature/buildscript

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -6,13 +6,18 @@ function get_ans {
     while [[ $ans != y ]] && [[ $ans != n ]]; do
       echo $1
       read ans < /dev/stdin
-      if [[ -z $ans ]]; then ans=$defans; fi
       if [[ $ans != y ]] && [[ $ans != n ]]; then echo "You must enter y or n"; fi
     done
 }
 
 
 #------------------------------------------------------------------------
+if [ $# -ne 1 ]; then
+   echo "Usage: "
+   echo "./build_container.sh <container-name>"
+   exit 1
+fi
+
 # Stop if anything goes wrong
 set -e
 
@@ -31,7 +36,6 @@ get_ans "Push to Docker Hub?"
 if [[ $ans == y ]] ; then
 
     # save previous image in case something goes wrong
-    docker rmi jcsda/docker-$CNAME:revert
     docker pull jcsda/docker-$CNAME:latest
     docker tag jcsda/docker-$CNAME:latest jcsda/docker-$CNAME:revert
     docker push jcsda/docker-$CNAME:revert

--- a/build_container.sh
+++ b/build_container.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#------------------------------------------------------------------------
+function get_ans {
+    ans=''
+    while [[ $ans != y ]] && [[ $ans != n ]]; do
+      echo $1
+      read ans < /dev/stdin
+      if [[ -z $ans ]]; then ans=$defans; fi
+      if [[ $ans != y ]] && [[ $ans != n ]]; then echo "You must enter y or n"; fi
+    done
+}
+
+
+#------------------------------------------------------------------------
+# Stop if anything goes wrong
+set -e
+
+export CNAME=${1:-"gnu-openmpi-dev"}
+
+
+#------------------------------------------------------------------------
+# Build image
+# tag it as beta for testing purposes - this will be retagged as latest
+
+docker image build -f Dockerfile.$CNAME -t jcsda/docker-$name:beta . 2>&1 | tee build.log
+#docker image build --no-cache -f Dockerfile.$CNAME -t jcsda/docker-$name:beta . 2>&1 | tee build.log
+
+#------------------------------------------------------------------------
+get_ans "Push to Docker Hub?"
+
+if [[ $ans == y ]] ; then
+
+    # save previous image in case something goes wrong
+    docker rmi jcsda/docker-$CNAME:revert
+    docker pull jcsda/docker-$CNAME:latest
+    docker tag jcsda/docker-$CNAME:latest jcsda/docker-$CNAME:revert
+    docker push jcsda/docker-$CNAME:revert
+    docker rmi jcsda/docker-$CNAME:latest
+
+    # push new image and re-tag it with latest
+    docker tag jcsda/docker-$CNAME:beta jcsda/docker-$CNAME:latest
+    docker rmi jcsda/docker-$CNAME:beta
+    docker push jcsda/docker-$CNAME:latest
+    
+fi
+#------------------------------------------------------------------------

--- a/build_container.sh
+++ b/build_container.sh
@@ -23,8 +23,7 @@ export CNAME=${1:-"gnu-openmpi-dev"}
 # Build image
 # tag it as beta for testing purposes - this will be retagged as latest
 
-docker image build -f Dockerfile.$CNAME -t jcsda/docker-$name:beta . 2>&1 | tee build.log
-#docker image build --no-cache -f Dockerfile.$CNAME -t jcsda/docker-$name:beta . 2>&1 | tee build.log
+docker image build --no-cache -f Dockerfile.${CNAME} -t jcsda/docker-${CNAME}:beta . 2>&1 | tee build.log
 
 #------------------------------------------------------------------------
 get_ans "Push to Docker Hub?"


### PR DESCRIPTION
This just adds a simple buildscript to make the docker image and push it to docker hub.

Before pushing, it first copies the existing :latest container and saves it as :revert.  This is intended as a fail-safe - if there is some problem with the build that goes unnoticed until tests start failing, then we can easily just copy revert back to latest to make sure the CI works again.