### PR TITLE
Feature/hpc dev clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ sbin
 doc
 libexec
 *.log
-ssh-key
+ssh-key/
 jedi-overlay.img
 *.sif
 *.nc

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -25,7 +25,7 @@ ENV NETCDF=/usr/local \
 
 COPY ssh-key/github_academy_rsa /root/github_academy_rsa
 
-RUN DOCKERSHELL BASH
+SHELL ["/bin/bash", "-c"]
 
 # build the jedi stack
 RUN mkdir -p /root/.ssh \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -33,7 +33,7 @@ RUN mkdir -p /root/.ssh \
     && eval "$(ssh-agent -s)" \
     && ssh-add /root/.ssh/github_academy_rsa \
     && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root \
-    && git clone git@github.com/jcsda-internal/jedi-stack.git \
+    && git clone git@github.com:jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout feature/bufr \
     && ./build_stack.sh "container-clang-mpich-dev" \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -23,8 +23,16 @@ ENV NETCDF=/usr/local \
    CPATH=/usr/local/include:$CPATH \
    PYTHONPATH=/usr/local/lib
 
+COPY ssh-key/github_academy_rsa /root/github_academy_rsa
+
+RUN DOCKERSHELL BASH
+
 # build the jedi stack
-RUN cd /root \
+RUN mkdir -p /root/.ssh \
+    && mv /root/github_academy_rsa /root/.ssh/github_academy_rsa \
+    && eval "$(ssh-agent -s)" \
+    && ssh-add /root/.ssh/github_academy_rsa \
+    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root && \
     && git clone https://github.com/jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout feature/bufr \
@@ -33,7 +41,8 @@ RUN cd /root \
     && chmod a+r /etc/jedi-stack-contents.log \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir /worktmp
+    && mkdir /worktmp \
+    && rm /root/.ssh/github_academy_rsa
 
 #Setup the root users environment
 ENV FC=mpifort \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -25,7 +25,7 @@ ENV NETCDF=/usr/local \
 
 # build the jedi stack
 RUN cd /root \
-    && git clone https://github.com/jcsda/jedi-stack.git \
+    && git clone https://github.com/jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout feature/bufr \
     && ./build_stack.sh "container-clang-mpich-dev" \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -32,8 +32,8 @@ RUN mkdir -p /root/.ssh \
     && mv /root/github_academy_rsa /root/.ssh/github_academy_rsa \
     && eval "$(ssh-agent -s)" \
     && ssh-add /root/.ssh/github_academy_rsa \
-    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root && \
-    && git clone https://github.com/jcsda-internal/jedi-stack.git \
+    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root \
+    && git clone git@github.com/jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout feature/bufr \
     && ./build_stack.sh "container-clang-mpich-dev" \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -1,4 +1,4 @@
-FROM  jcsda/docker_base-clang-mpich-dev:beta
+FROM  jcsda/docker_base-clang-mpich-dev-mlnx:mlnx
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
 # set environment variables manually
@@ -27,7 +27,7 @@ ENV NETCDF=/usr/local \
 RUN cd /root \
     && git clone https://github.com/jcsda/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout develop \
+    && git checkout feature/bufr \
     && ./build_stack.sh "container-clang-mpich-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:experimental
 FROM  jcsda/docker_base-clang-mpich-dev-mlnx:mlnx
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
@@ -23,16 +24,18 @@ ENV NETCDF=/usr/local \
    CPATH=/usr/local/include:$CPATH \
    PYTHONPATH=/usr/local/lib
 
-COPY ssh-key/github_academy_rsa /root/github_academy_rsa
-
 SHELL ["/bin/bash", "-c"]
 
+# Download public key for github.com
+RUN mkdir -p -m 0600 ~/.ssh && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# set up ssh authentication
+RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+
 # build the jedi stack
-RUN mkdir -p /root/.ssh \
-    && mv /root/github_academy_rsa /root/.ssh/github_academy_rsa \
-    && eval "$(ssh-agent -s)" \
-    && ssh-add /root/.ssh/github_academy_rsa \
-    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root \
+RUN --mount=type=ssh,id=github_ssh_key cd /root \
+    && source /etc/profile \
     && git clone git@github.com:jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout feature/bufr \
@@ -41,8 +44,7 @@ RUN mkdir -p /root/.ssh \
     && chmod a+r /etc/jedi-stack-contents.log \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir /worktmp \
-    && rm /root/.ssh/github_academy_rsa
+    && mkdir /worktmp
 
 #Setup the root users environment
 ENV FC=mpifort \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -38,7 +38,7 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && source /etc/profile \
     && git clone git@github.com:jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
-    && git checkout feature/bufr \
+    && git checkout develop \
     && ./build_stack.sh "container-clang-mpich-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -19,8 +19,16 @@ ENV NETCDF=/usr/local \
    MPI_FC=mpifort \
    PYTHONPATH=/usr/local/lib
 
+COPY ssh-key/github_academy_rsa /root/github_academy_rsa
+
+RUN DOCKERSHELL BASH
+
 # build the jedi stack
-RUN cd /root \
+RUN mkdir -p /root/.ssh \
+    && mv /root/github_academy_rsa /root/.ssh/github_academy_rsa \
+    && eval "$(ssh-agent -s)" \
+    && ssh-add /root/.ssh/github_academy_rsa \
+    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root && \
     && git clone https://github.com/jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout develop \
@@ -29,7 +37,8 @@ RUN cd /root \
     && chmod a+r /etc/jedi-stack-contents.log \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir /worktmp
+    && mkdir /worktmp \
+    && rm /root/.ssh/github_academy_rsa
 
 #Setup the root users environment
 ENV FC=mpifort \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -29,7 +29,7 @@ RUN mkdir -p /root/.ssh \
     && eval "$(ssh-agent -s)" \
     && ssh-add /root/.ssh/github_academy_rsa \
     && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root \
-    && git clone git@//github.com/jcsda-internal/jedi-stack.git \
+    && git clone git@github.com:JCSDA-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout develop \
     && ./build_stack.sh "container-gnu-openmpi-dev" \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:experimental
 FROM  jcsda/docker_base-gnu-openmpi-dev:beta
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
@@ -19,16 +20,18 @@ ENV NETCDF=/usr/local \
    MPI_FC=mpifort \
    PYTHONPATH=/usr/local/lib
 
-COPY ssh-key/github_academy_rsa /root/github_academy_rsa
-
 SHELL ["/bin/bash", "-c"]
 
+# Download public key for github.com
+RUN mkdir -p -m 0600 ~/.ssh && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# set up ssh authentication
+RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+
 # build the jedi stack
-RUN mkdir -p /root/.ssh \
-    && mv /root/github_academy_rsa /root/.ssh/github_academy_rsa \
-    && eval "$(ssh-agent -s)" \
-    && ssh-add /root/.ssh/github_academy_rsa \
-    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root \
+RUN --mount=type=ssh,id=github_ssh_key cd /root \
+    && source /etc/profile \
     && git clone git@github.com:JCSDA-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout develop \
@@ -37,8 +40,7 @@ RUN mkdir -p /root/.ssh \
     && chmod a+r /etc/jedi-stack-contents.log \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir /worktmp \
-    && rm /root/.ssh/github_academy_rsa
+    && mkdir /worktmp
 
 #Setup the root users environment
 ENV FC=mpifort \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -21,7 +21,7 @@ ENV NETCDF=/usr/local \
 
 COPY ssh-key/github_academy_rsa /root/github_academy_rsa
 
-RUN DOCKERSHELL BASH
+SHELL ["/bin/bash", "-c"]
 
 # build the jedi stack
 RUN mkdir -p /root/.ssh \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -21,7 +21,7 @@ ENV NETCDF=/usr/local \
 
 # build the jedi stack
 RUN cd /root \
-    && git clone https://github.com/jcsda/jedi-stack.git \
+    && git clone https://github.com/jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout develop \
     && ./build_stack.sh "container-gnu-openmpi-dev" \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -28,8 +28,8 @@ RUN mkdir -p /root/.ssh \
     && mv /root/github_academy_rsa /root/.ssh/github_academy_rsa \
     && eval "$(ssh-agent -s)" \
     && ssh-add /root/.ssh/github_academy_rsa \
-    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root && \
-    && git clone https://github.com/jcsda-internal/jedi-stack.git \
+    && ssh -T -o "StrictHostKeyChecking=no" git@github.com; cd /root \
+    && git clone git@//github.com/jcsda-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout develop \
     && ./build_stack.sh "container-gnu-openmpi-dev" \

--- a/Dockerfile.intel-oneapi-dev
+++ b/Dockerfile.intel-oneapi-dev
@@ -1,0 +1,95 @@
+# syntax=docker/dockerfile:experimental
+FROM  jcsda/docker_base-intel-oneapi-dev:latest
+LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
+
+SHELL ["/bin/bash", "-c"]
+
+RUN rm -f /usr/bin/gmake && \
+    ln -s /usr/bin/make /usr/bin/gmake
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends -o=Dpkg::Use-Pty=0 \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        libexpat1-dev \
+        libssl-dev \
+        m4 \
+        pkg-config \
+        python \
+        vim \
+        wget \
+        --
+
+ENV I_MPI_THREAD_SPLIT=1 \
+    I_MPI_LIBRARY_KIND='release_mt'
+
+# set environment variables manually
+ENV CMAKE_C_COMPILER=mpiicc \
+    CMAKE_CXX_COMPILER=mpiicpc \
+    CMAKE_Fortran_COMPILER=mpiifort \
+    CMAKE_Platform=linux.intel \
+    CMAKE_PREFIX_PATH=/usr/local \
+    NETCDF=/usr/local \
+    CC=mpiicc \
+    CXX=mpiicpc \
+    FC=mpiifort \
+    MPI_CC=mpiicc \
+    MPI_CXX=mpiicpc \
+    MPI_FC=mpiifort \
+    SERIAL_CC=icc \
+    SERIAL_CXX=icpc \
+    SERIAL_FC=ifort
+    PNETCDF=/usr/local \
+    HDF5_ROOT=/usr/local \
+    PIO=/usr/local \
+    BOOST_ROOT=/usr/local \
+    EIGEN3_INCLUDE_DIR=/usr/local \
+    SERIAL_CC=clang \
+    SERIAL_CXX=clang++ \
+    SERIAL_FC=gfortran \
+    PATH=/usr/local/bin:$PATH \
+    LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
+    LIBRARY_PATH=/usr/local/lib:$LIBRARY_PATH \
+    CPATH=/usr/local/include:$CPATH \
+    PYTHONPATH=/usr/local/lib:$PYTHONPATH
+
+# Download public key for github.com
+RUN mkdir -p -m 0600 ~/.ssh && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# set up ssh authentication
+RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+
+# build the jedi stack
+RUN --mount=type=ssh,id=github_ssh_key cd /root \
+    && source /etc/profile \
+    && git clone git@github.com:jcsda-internal/jedi-stack.git \
+    && cd jedi-stack/buildscripts \
+    && git checkout feature/intel-oneapi \
+    && ./build_stack.sh "container-intel-oneapi-dev" \
+    && mv ../jedi-stack-contents.log /etc \
+    && chmod a+r /etc/jedi-stack-contents.log \
+    && rm -rf /root/jedi-stack \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /worktmp
+
+#Make a non-root user:jedi / group:jedi for running MPI
+RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi && \
+    echo "export FC=mpiifort" >> ~jedi/.bashrc && \
+    echo "export CC=mpiicc" >> ~jedi/.bashrc && \
+    echo "export CXX=mpiicpc" >> ~jedi/.bashrc && \
+    echo "export PYTHONPATH=/usr/local/lib:$PYTHONPATH" >> ~jedi/.bashrc && \
+    echo "ulimit -s unlimited" >> ~jedi/.bashrc && \
+    echo "ulimit -v unlimited" >> ~jedi/.bashrc && \
+    echo "[credential]\n    helper = cache --timeout=7200" >> ~jedi/.gitconfig && \
+    mkdir ~jedi/.openmpi && \
+    echo "rmaps_base_oversubscribe = 1" >> ~jedi/.openmpi/mca-params.conf && \
+    chown -R jedi:jedi ~jedi/.gitconfig ~jedi/.openmpi
+
+CMD ["/bin/bash" , "-l"]

--- a/Dockerfile.intel-oneapi-dev
+++ b/Dockerfile.intel-oneapi-dev
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM  jcsda/docker_base-intel-oneapi-dev:latest
+FROM  jcsda/docker_base-intel-oneapi-dev:beta
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
 SHELL ["/bin/bash", "-c"]
@@ -44,7 +44,7 @@ ENV CMAKE_C_COMPILER=mpiicc \
     MPI_FC=mpiifort \
     SERIAL_CC=icc \
     SERIAL_CXX=icpc \
-    SERIAL_FC=ifort
+    SERIAL_FC=ifort \
     PNETCDF=/usr/local \
     HDF5_ROOT=/usr/local \
     PIO=/usr/local \
@@ -76,7 +76,6 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \
     && rm -rf /root/jedi-stack \
-    && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp
 
 #Make a non-root user:jedi / group:jedi for running MPI
@@ -87,7 +86,7 @@ RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi && \
     echo "export PYTHONPATH=/usr/local/lib:$PYTHONPATH" >> ~jedi/.bashrc && \
     echo "ulimit -s unlimited" >> ~jedi/.bashrc && \
     echo "ulimit -v unlimited" >> ~jedi/.bashrc && \
-    echo "[credential]\n    helper = cache --timeout=7200" >> ~jedi/.gitconfig && \
+    echo -e "[credential]\n    helper = cache --timeout=7200" >> ~jedi/.gitconfig && \
     mkdir ~jedi/.openmpi && \
     echo "rmaps_base_oversubscribe = 1" >> ~jedi/.openmpi/mca-params.conf && \
     chown -R jedi:jedi ~jedi/.gitconfig ~jedi/.openmpi

--- a/build_container.sh
+++ b/build_container.sh
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------
 if [ $# -ne 1 ]; then
    echo "Usage: "
-   echo "./build_container.sh <container-name>"
+   echo "./build_container.sh <container-name> <tag>"
    exit 1
 fi
 
@@ -15,11 +15,12 @@ fi
 set -e
 
 export CNAME=${1:-"gnu-openmpi-dev"}
+export TAG=${2:-"beta"}
 
 #------------------------------------------------------------------------
 # Build image
 # tag it as beta for testing purposes - this will be retagged as latest
 
-docker image build --no-cache -f Dockerfile.${CNAME} -t jcsda/docker-${CNAME}:beta . 2>&1 | tee build.log
+docker image build --no-cache -f Dockerfile.${CNAME} -t jcsda/docker-${CNAME}:${TAG} . 2>&1 | tee build.log
 
 #------------------------------------------------------------------------

--- a/build_container.sh
+++ b/build_container.sh
@@ -5,7 +5,7 @@
 
 
 #------------------------------------------------------------------------
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ]; then
    echo "Usage: "
    echo "./build_container.sh <container-name> <tag>"
    exit 1

--- a/build_container.sh
+++ b/build_container.sh
@@ -16,11 +16,13 @@ set -e
 
 export CNAME=${1:-"gnu-openmpi-dev"}
 export TAG=${2:-"beta"}
+KEY=$HOME/.ssh/github_academy_rsa
 
 #------------------------------------------------------------------------
 # Build image
-# tag it as beta for testing purposes - this will be retagged as latest
+# tag it as beta for testing purposes - this will be retagged as # # latest
 
-docker image build --no-cache -f Dockerfile.${CNAME} -t jcsda/docker-${CNAME}:${TAG} . 2>&1 | tee build.log
+export DOCKER_BUILDKIT=1
+docker build --no-cache --ssh github_ssh_key=${KEY} --progress=plain -f Dockerfile.${CNAME} -t jcsda/docker-${CNAME}:${TAG} . 2>&1 | tee build.log
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This adds a dockerfile for intel oneapi.  It also implements @slawrence87544 's more secure method for importing ssh keys into the docker builds.

### Issue(s) addressed

Link the issues to be closed with this PR

See also 
https://github.com/JCSDA-internal/docker_base/pull/31
https://github.com/JCSDA-internal/jedi-tools/issues/134
https://github.com/JCSDA-internal/containers/pull/48

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- waiting on JCSDA/eckit/pull/<pr_number>
- waiting on JCSDA/atlas/pull/<pr_number>

## Impact

If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
Requires changes in the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ufo
- [ ] ...

If changes in this PR require updating test data on AWS please add an "update test data" label and list the test data that needs to be updated to the best of your knowledge (example below).
Requires updating AWS test data for the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ...

Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
git commit --allow-empty -m 'trigger pipeline'
