### PR TITLE
change jedi user id in containers

### DIFF
--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -56,7 +56,7 @@ ENV FC=mpifort \
    CXX=mpicxx
 
 #Make a non-root user:jedi / group:jedi for running MPI
-RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi && \
+RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi --uid 43891 && \
     echo "export FC=mpifort" >> ~jedi/.bashrc && \
     echo "export CC=mpicc" >> ~jedi/.bashrc && \
     echo "export CXX=mpicxx" >> ~jedi/.bashrc && \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -52,7 +52,7 @@ ENV FC=mpifort \
    CXX=mpicxx
 
 #Make a non-root user:jedi / group:jedi for running MPI
-RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi && \
+RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi --uid 43891 && \
     echo "export FC=mpifort" >> ~jedi/.bashrc && \
     echo "export CC=mpicc" >> ~jedi/.bashrc && \
     echo "export CXX=mpicxx" >> ~jedi/.bashrc && \


### PR DESCRIPTION
## Description

Perhaps this should have been a bugfix branch...

@kbhargava ran into an interesting bug in the containers. 

In order to avoid running MPI as root in the Docker containers, we added a user called jedi.   Normally this causes no problems.    However, when a user enters a singularity container with `singularity shell` or `singularity exec`, singularity takes the user id on the host and copies into the `/etc/passwd` file in the container.   This can lead to a problem if the numerical value of the user id is the same on the host as it is for the jedi user in the container.

For example, consider my AWS ubuntu node.    There the last line in my `/etc/passwd` file shows the user `ubuntu` as user number 1000.

```
ubuntu@ip-172-31-9-105:~$ tail -n 1 /etc/passwd
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
```

Now, look at the last two lines of the same file in the container:

```
ubuntu@ip-172-31-9-105:~$ singularity exec -e jedi-tutorial_latest.sif tail -n 2 /etc/passwd
jedi:x:1000:1000::/home/jedi:/bin/bash
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
```

So, singularity has not changed the user id: it is still 1000.  But, there are now two users with a user id of 1000, namely `jedi` and `ubuntu`.  System commands such as `whoami` or `id` choose the first one:

```bash
ubuntu@ip-172-31-9-105:~$ id
uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),20(dialout),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev),108(lxd),114(netdev),999(docker)
ubuntu@ip-172-31-9-105:~$ singularity exec -e jedi-tutorial_latest.sif id
uid=1000(jedi) gid=1000(jedi) groups=1000(jedi),4(adm),20(dialout),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev),108(lxd),114(netdev),999(docker)
```

This caused problems for @kbhargava for ssh git authentication.   The container is looking in `/home/jedi/.ssh` for the ssh key instead of `$HOME/.ssh`.  

### Issue(s) addressed

## Acceptance Criteria (Definition of Done)

The jedi user in the singularity container has (in all likelihood) a different user id than the general user so conflicts like the git ssh authentication example referred to above are avoided.

## Dependencies

## Impact

If accepted, I will also include these changes in my current feature branch in the `containers` repo.  So, the change will also be incorporated in the intel containers but there is no need for another PR in that repo.

## Test Data

None