### PR TITLE
Bugfix/bufr

### DIFF
--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -2,6 +2,12 @@
 FROM  jcsda/docker_base-clang-mpich-dev:__TAG__
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
+# additional system packages
+RUN apt-get update -y && \
+   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       libgmp-dev libmpfr-dev libboost-thread-dev && \
+   rm -rf /var/lib/apt/lists/*
+
 # set environment variables manually
 ENV NETCDF=/usr/local \
    PNETCDF=/usr/local \

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -44,7 +44,7 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && chmod a+r /etc/jedi-stack-contents.log \
     && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
     && python setup.py build \
-    && python setup.py install --prefix=/usr/local --install-lib=/usr/local/lib/python3.8/site-packages \
+    && python setup.py install --prefix=/usr/local \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -42,6 +42,9 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && ./build_stack.sh "container-clang-mpich-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \
+    && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
+    && python setup.py build \
+    && python setup.py install --prefix=/usr/local --install-lib=/usr/local/lib/python3.8/site-packages \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -1,6 +1,12 @@
 # syntax=docker/dockerfile:experimental
-FROM  jcsda/docker_base-gnu-openmpi-dev:__TAG__
+FROM  jcsda/docker_base-gnu-openmpi-dev:latest
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
+
+# additional system packages
+RUN apt-get update -y && \
+   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       libgmp-dev libmpfr-dev libboost-thread-dev && \
+   rm -rf /var/lib/apt/lists/*
 
 # set environment variables manually
 ENV NETCDF=/usr/local \
@@ -40,7 +46,7 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && chmod a+r /etc/jedi-stack-contents.log \
     && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
     && python setup.py build \
-    && python setup.py install --prefix=/usr/local --install-lib=/usr/local/lib/python3.8/site-packages \
+    && python setup.py install --prefix=/usr/local \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM  jcsda/docker_base-gnu-openmpi-dev:latest
+FROM  jcsda/docker_base-gnu-openmpi-dev:__TAG__
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
 # additional system packages

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -38,6 +38,9 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && ./build_stack.sh "container-gnu-openmpi-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \
+    && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
+    && python setup.py build \
+    && python setup.py install --prefix=/usr/local --install-lib=/usr/local/lib/python3.8/site-packages \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp


### PR DESCRIPTION
## Description

This fixes #75, installing the `ncepbufr` python module in the gnu and clang containers.  

In order to test this you need to use the `feature/intel-oneapi-app` branch of jedi-stack.

This is because I had already implemented the bufr fix when building recent intel oneapi containers.

I also combined this effort with another.  In addition to installing the python module in the container, I also used this opportunity to install the new [ecbuild, eckit, fckit, and atlas](https://github.com/JCSDA-internal/jedi-stack/issues/19) in the container.  

To get atlas to install with CGAL, I had to install the `libgmp-dev`,  `libmpfr-dev`, and  `libboost-thread-dev` packages.  I don't understand why - [the build script for CGAL disables these](https://github.com/JCSDA-internal/jedi-stack/blob/d32456cb1a1074159c503036f505bba782bbeb9a/buildscripts/libs/build_cgal.sh#L68).  CGAL itself built fine without them but Atlas found cgal and tried to initialize it and failed without these components.  Since installing them is easy, that is the quickest solution

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #75
- partially-fixes #https://github.com/JCSDA-internal/jedi-stack/issues/19

## Acceptance Criteria (Definition of Done)

The container builds, the `ncepbufr` module properly loads in the docker container and all ioda-converters tests pass.

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- [ ] waiting on 


## Impact

None

## Test Data

None