### PR TITLE
Upgrade jopa-gnu-ompi-ci container

### DIFF
--- a/UKMO/Dockerfile.jopa-gnu-ompi-ci
+++ b/UKMO/Dockerfile.jopa-gnu-ompi-ci
@@ -2,6 +2,9 @@
 FROM jcsda/jopa-gnu-ompi-dev:latest
 LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
 
+# Mount external volume for AWS CodeBuild
+VOLUME /var/lib/docker
+
 #clone and build fckit
 RUN mkdir -p /usr/local/src && \
    cd /usr/local/src && \
@@ -12,7 +15,7 @@ RUN mkdir -p /usr/local/src && \
    cd && rm -rf /usr/local/src/{build,fckit*}
 
 # clone and build shumlib
-RUN yum install -y subversion
+RUN yum install -y subversion awscli
 
 ENV SHUM_ROOT=/root/r4621_387_jedi_test_branch/build/ssec-ifort-icc
 
@@ -60,6 +63,19 @@ RUN mkdir -p /opt/build/atlas && \
     cd /opt/build/atlas && \
     ecbuild --build=Release -Dtrans_DIR=/opt/build/trans \
             --eckit_ROOT=/usr/local /root/src/atlas
+
+#Make a non-root user:jedi / group:jedi for running MPI
+RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi --uid 43891 && \
+    echo "export FC=mpifort" >> ~jedi/.bashrc && \
+    echo "export CC=mpicc" >> ~jedi/.bashrc && \
+    echo "export CXX=mpicxx" >> ~jedi/.bashrc && \
+    echo "export PYTHONPATH=/usr/local/lib:$PYTHONPATH" >> ~jedi/.bashrc && \
+    echo "ulimit -s unlimited" >> ~jedi/.bashrc && \
+    echo "ulimit -v unlimited" >> ~jedi/.bashrc && \
+    printf "[credential]\n    helper = cache --timeout=7200\n" >> ~jedi/.gitconfig && \
+    mkdir ~jedi/.openmpi && \
+    echo "rmaps_base_oversubscribe = 1" >> ~jedi/.openmpi/mca-params.conf && \
+    chown -R jedi:jedi ~jedi/.gitconfig ~jedi/.openmpi
 
 RUN cd / && \
     rm -rf {/usr/local/src/*,/var/tmp/*,/root/src/*}

--- a/UKMO/build_container.sh
+++ b/UKMO/build_container.sh
@@ -13,4 +13,5 @@ set -e
 export TAG=${1:-"beta"}
 KEY=$HOME/.ssh/githubnew_rsa
 
+export DOCKER_BUILDKIT=1
 docker build --secret id=pwd,src=./credentials/mosrs --ssh github_ssh_key=${KEY} --progress=plain -f Dockerfile.jopa-gnu-ompi-ci -t jopa-gnu-ompi-ci:$TAG context


### PR DESCRIPTION
## Description

This add three enhancements to the `jopa-gnu-ompi-ci` container, for use with CI:
1. adds a `jedi` user 
2. adds `awscli`
3. adds a docker mount for AWS CodeBuild ([see here for details](https://github.com/JCSDA-internal/containers/issues/63))

The new docker container has been published on AWS ECR.  To retrieve it, enter:

```bash
aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 469205354006.dkr.ecr.us-east-1.amazonaws.com
```

```bash
docker pull 469205354006.dkr.ecr.us-east-1.amazonaws.com/jopa-gnu-ompi-ci:beta
```

### Issue(s) addressed

These changes are necessary for facilitating CI

## Acceptance Criteria (Definition of Done)

Containers build with the added features.  um-bundle builds in docker container and ops-um-jedi tests pass

## Dependencies

None

## Impact

None
