### PR TITLE
setup locales properly

### DIFF
--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -64,6 +64,16 @@ ENV FC=mpifort \
    CC=mpicc \
    CXX=mpicxx
 
+# set time zone
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata locales && \
+    ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime && \
+    locale-gen --purge en_US.UTF-8 && \
+    dpkg-reconfigure --frontend noninteractive tzdata && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale "LANG=en_US.UTF-8" && \
+    update-locale "LANGUAGE=en_US:en"
+
 #Make a non-root user:jedi / group:jedi for running MPI
 RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi --uid 43891 && \
     echo "export FC=mpifort" >> ~jedi/.bashrc && \

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -60,6 +60,16 @@ ENV FC=mpifort \
    CC=mpicc \
    CXX=mpicxx
 
+# set time zone
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata locales && \
+    ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime && \
+    locale-gen --purge en_US.UTF-8 && \
+    dpkg-reconfigure --frontend noninteractive tzdata && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale "LANG=en_US.UTF-8" && \
+    update-locale "LANGUAGE=en_US:en"
+
 #Make a non-root user:jedi / group:jedi for running MPI
 RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi --uid 43891 && \
     echo "export FC=mpifort" >> ~jedi/.bashrc && \


### PR DESCRIPTION
## Description

In preparation for the mpas release, and specifically for the tutorials, we want to eliminate these warning messages that were noted also in the previous release and at the last academy.  They appear in the singularity containers when running ecbuild:

```
perl: warning: Falling back to the standard locale ("C").
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = "en_US:en",
	LC_ALL = "",
	LC_MESSAGES = "",
	LANG = "en_US.UTF-8"
```

### Issue(s) addressed

Link the issues to be closed with this PR
- partially-fixes #https://github.com/JCSDA-internal/containers/issues/63

## Acceptance Criteria (Definition of Done)

The warnings described above no longer appear

## Dependencies

None

## Impact

None