### PR TITLE
update shumlib branch

### DIFF
--- a/UKMO/Dockerfile.jopa-gnu-ompi-ci
+++ b/UKMO/Dockerfile.jopa-gnu-ompi-ci
@@ -21,8 +21,8 @@ ENV SHUM_ROOT=/opt/build/shumlib/vm-x86-gfortran-gcc/
 
 RUN --mount=type=secret,id=pwd mkdir -p /opt && \
     cd /opt && \
-    svn checkout --non-interactive --username=markmiesch --password=$(cat /run/secrets/pwd) https://code.metoffice.gov.uk/svn/utils/shumlib/branches/dev/stevensandbach/r4621_387_jedi_test_branch && \
-    cd r4621_387_jedi_test_branch && \
+    svn checkout --non-interactive --username=markmiesch --password=$(cat /run/secrets/pwd) https://code.metoffice.gov.uk/svn/utils/shumlib/branches/dev/stevensandbach/r5615_387_jedibranch && \
+    cd r5615_387_jedibranch && \
     make -f make/vm-x86-gfortran-gcc.mk && \
     mkdir -p /opt/build/shumlib && \
     mv build/* /opt/build/shumlib && \


### PR DESCRIPTION
## Description

use latest shumlib branch

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

up-to-date shumlib branch is used for ops-um-jedi ci container

## Dependencies

none

## Impact

None
