### PR TITLE
add h5py and eccodes 

### DIFF
--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -42,18 +42,15 @@ RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
 # build the jedi stack
 RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && source /etc/profile \
-    && git clone git@github.com:jcsda-internal/jedi-stack.git \
+    && git clone git@github.com:JCSDA-internal/jedi-stack.git \
     && cd jedi-stack/buildscripts \
     && git checkout develop \
     && ./build_stack.sh "container-clang-mpich-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \
-    && sed -i 's/site/dist/g' /root/jedi-stack/pkg/NCEPLIBS-bufr/python/CMakeLists.txt  \
-    && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build \
-    && make install \
     && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
     && python setup.py build \
-    && python setup.py install --prefix=/usr/local \
+    && python setup.py install --prefix=/usr/local --install-lib=/usr/local/lib/python3.8/dist-packages\
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/Dockerfile.clang-mpich-dev
+++ b/Dockerfile.clang-mpich-dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 FROM  jcsda/docker_base-clang-mpich-dev:__TAG__
-LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
+LABEL maintainer "Maryam Abdi-Oskouei <maryamao@ucar.edu>"
 
 # additional system packages
 RUN apt-get update -y && \
@@ -48,6 +48,9 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && ./build_stack.sh "container-clang-mpich-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \
+    && sed -i 's/site/dist/g' /root/jedi-stack/pkg/NCEPLIBS-bufr/python/CMakeLists.txt  \
+    && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build \
+    && make install \
     && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
     && python setup.py build \
     && python setup.py install --prefix=/usr/local \
@@ -63,6 +66,10 @@ RUN git config --global --unset url.ssh://git@github.com/.insteadOf \
 ENV FC=mpifort \
    CC=mpicc \
    CXX=mpicxx
+
+# build h5py and eccodes
+RUN CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/local pip install --no-binary=h5py h5py \
+    &&  pip install eccodes
 
 # set time zone
 RUN apt-get update && \
@@ -87,4 +94,5 @@ RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi --uid 43891 && \
     echo "rmaps_base_oversubscribe = 1" >> ~jedi/.openmpi/mca-params.conf && \
     chown -R jedi:jedi ~jedi/.gitconfig ~jedi/.openmpi
 
+VOLUME /var/lib/docker
 CMD ["/bin/bash" , "-l"]

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 FROM  jcsda/docker_base-gnu-openmpi-dev:__TAG__
-LABEL maintainer "Mark Miesch <miesch@ucar.edu>"
+LABEL maintainer "Maryam Abdi-Oskouei <maryamao@ucar.edu>"
 
 # additional system packages
 RUN apt-get update -y && \
@@ -44,6 +44,9 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && ./build_stack.sh "container-gnu-openmpi-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \
+    && sed -i 's/site/dist/g' /root/jedi-stack/pkg/NCEPLIBS-bufr/python/CMakeLists.txt  \
+    && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build \
+    && make install \
     && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
     && python setup.py build \
     && python setup.py install --prefix=/usr/local \
@@ -59,6 +62,11 @@ RUN git config --global --unset url.ssh://git@github.com/.insteadOf \
 ENV FC=mpifort \
    CC=mpicc \
    CXX=mpicxx
+
+# build h5py and eccodes
+RUN CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/local pip install --no-binary=h5py h5py \
+    &&  pip install eccodes
+
 
 # set time zone
 RUN apt-get update && \
@@ -83,4 +91,5 @@ RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi --uid 43891 && \
     echo "rmaps_base_oversubscribe = 1" >> ~jedi/.openmpi/mca-params.conf && \
     chown -R jedi:jedi ~jedi/.gitconfig ~jedi/.openmpi
 
+VOLUME /var/lib/docker
 CMD ["/bin/bash" , "-l"]

--- a/Dockerfile.gnu-openmpi-dev
+++ b/Dockerfile.gnu-openmpi-dev
@@ -44,12 +44,9 @@ RUN --mount=type=ssh,id=github_ssh_key cd /root \
     && ./build_stack.sh "container-gnu-openmpi-dev" \
     && mv ../jedi-stack-contents.log /etc \
     && chmod a+r /etc/jedi-stack-contents.log \
-    && sed -i 's/site/dist/g' /root/jedi-stack/pkg/NCEPLIBS-bufr/python/CMakeLists.txt  \
-    && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build \
-    && make install \
     && cd /root/jedi-stack/pkg/NCEPLIBS-bufr/build/python \
     && python setup.py build \
-    && python setup.py install --prefix=/usr/local \
+    && python setup.py install --prefix=/usr/local --install-lib=/usr/local/lib/python3.8/dist-packages \
     && rm -rf /root/jedi-stack \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /worktmp

--- a/build_container.sh
+++ b/build_container.sh
@@ -16,7 +16,7 @@ set -e
 
 export CNAME=${1:-"gnu-openmpi-dev"}
 export TAG=${2:-"beta"}
-KEY=$HOME/.ssh/github_academy_rsa
+KEY=$HOME/.ssh/id_rsa
 
 #------------------------------------------------------------------------
 # Specify proper tag


### PR DESCRIPTION
## Description
This PR updates the Dockerfile for gnu and clang containers to:
 - build NCEPLIBS-bufr python package manually. I had to implement a hacky way to build it in `dist-package` instead of `site-package`. I'm not sure if there is a better way for building this package or why building it in `site-package` was unsuccessful. 
 - build eccodes and h5py python packages. This can be replaced with the new method of building python packages in jedi-stack in the future. 
 - add `VOLUME /var/lib/docker` needed by CodeBuild

The new containers are uploaded to AWS ECR and are currently used in all CI. 

### Issue(s) addressed

related to https://github.com/JCSDA-internal/jedi-stack/issues/146

## Acceptance Criteria (Definition of Done)
Successfully build clang and gnu containers 

## Dependencies
None

## Impact
None
